### PR TITLE
Fix redundant null checks flagged by CodeQL

### DIFF
--- a/src/tx/primitives/serialize.cpp
+++ b/src/tx/primitives/serialize.cpp
@@ -296,7 +296,7 @@ bool DeserializeTransaction(const std::vector<std::uint8_t>& data, std::size_t* 
     if (!read_varint(data, cursor, &vin_count)) return false;
     if (has_witness && vin_count == 0) return false;
     if (vin_count > static_cast<std::uint64_t>(std::numeric_limits<std::size_t>::max())) return false;
-    const std::size_t remaining_inputs = (cursor && *cursor <= data.size()) ? data.size() - *cursor : 0;
+    const std::size_t remaining_inputs = (*cursor <= data.size()) ? data.size() - *cursor : 0;
     if (kMinInputBytes == 0 || vin_count > remaining_inputs / kMinInputBytes) return false;
     out->vin.resize(static_cast<std::size_t>(vin_count));
     if (!DeserializeInputs(data, cursor, out, legacy_varint)) return false;
@@ -304,7 +304,7 @@ bool DeserializeTransaction(const std::vector<std::uint8_t>& data, std::size_t* 
     std::uint64_t vout_count = 0;
     if (!read_varint(data, cursor, &vout_count)) return false;
     if (vout_count > static_cast<std::uint64_t>(std::numeric_limits<std::size_t>::max())) return false;
-    const std::size_t remaining_outputs = (cursor && *cursor <= data.size()) ? data.size() - *cursor : 0;
+    const std::size_t remaining_outputs = (*cursor <= data.size()) ? data.size() - *cursor : 0;
     if (kMinOutputBytes == 0 || vout_count > remaining_outputs / kMinOutputBytes) return false;
     out->vout.resize(static_cast<std::size_t>(vout_count));
     if (!DeserializeOutputs(data, cursor, out, legacy_varint)) return false;
@@ -342,7 +342,7 @@ bool DeserializeTransaction(const std::vector<std::uint8_t>& data, std::size_t* 
     std::uint64_t vin_count = 0;
     if (!read_varint(data, cursor, &vin_count)) return false;
     if (vin_count > static_cast<std::uint64_t>(std::numeric_limits<std::size_t>::max())) return false;
-    const std::size_t remaining_inputs = (cursor && *cursor <= data.size()) ? data.size() - *cursor : 0;
+    const std::size_t remaining_inputs = (*cursor <= data.size()) ? data.size() - *cursor : 0;
     if (kMinInputBytes == 0 || vin_count > remaining_inputs / kMinInputBytes) return false;
     out->vin.resize(static_cast<std::size_t>(vin_count));
     for (auto& in : out->vin) {
@@ -380,7 +380,7 @@ bool DeserializeTransaction(const std::vector<std::uint8_t>& data, std::size_t* 
     std::uint64_t vout_count = 0;
     if (!read_varint(data, cursor, &vout_count)) return false;
     if (vout_count > static_cast<std::uint64_t>(std::numeric_limits<std::size_t>::max())) return false;
-    const std::size_t remaining_outputs = (cursor && *cursor <= data.size()) ? data.size() - *cursor : 0;
+    const std::size_t remaining_outputs = (*cursor <= data.size()) ? data.size() - *cursor : 0;
     if (kMinOutputBytes == 0 || vout_count > remaining_outputs / kMinOutputBytes) return false;
     out->vout.resize(static_cast<std::size_t>(vout_count));
     if (!DeserializeOutputs(data, cursor, out, legacy_varint)) return false;


### PR DESCRIPTION
## Summary

- Remove redundant `cursor &&` null checks in `src/tx/primitives/serialize.cpp`
- The pointer `cursor` is already dereferenced earlier in the function, so the null check provides no protection
- Flagged as high severity by CodeQL static analysis

## Details

Lines 299, 307, 345, and 383 check `cursor && *cursor <= data.size()`, but `cursor` is already dereferenced at lines 281, 283, 292, and 296. If `cursor` were null, the code would crash before reaching these checks, making them redundant and misleading.

## Test plan

- [x] Verified diff matches CodeQL alert locations
- [ ] CI should pass with no build errors