### PR TITLE
Implement eviction-based peer management for seed nodes

### DIFF
--- a/src/net/peer_manager.hpp
+++ b/src/net/peer_manager.hpp
@@ -87,6 +87,13 @@ class PeerManager {
   bool IsAddressBannedLocked(const std::string& address) const;
   bool AllowInboundBeforeHandshakeLocked(const std::string& address,
                                         std::chrono::steady_clock::time_point now);
+  // Evict the least useful inbound peer to make room for a new connection.
+  // Returns the evicted peer's ID, or 0 if no peer could be evicted.
+  std::uint64_t EvictInboundPeerLocked();
+  // Decide whether to accept a new inbound connection, potentially evicting
+  // an existing peer if at capacity. Returns true if the connection should
+  // be accepted.
+  bool ShouldAcceptInboundLocked(const std::string& address);
   static std::string ExtractHost(const std::string& address);
   static std::string SubnetKey(const std::string& address);
 

--- a/src/node/qryptd.cpp
+++ b/src/node/qryptd.cpp
@@ -553,6 +553,17 @@ void ApplyEnvironmentOverrides(Options* opts) {
   if (auto value = GetEnvValue("QRY_LOG_MAX_FILES")) {
     opts->log_max_files = static_cast<std::size_t>(std::stoul(*value));
   }
+
+  // Peer connection limits (environment variable overrides).
+  if (auto value = GetEnvValue("QRY_MAX_INBOUND_PEERS")) {
+    opts->max_inbound_peers = static_cast<std::size_t>(std::stoul(*value));
+  }
+  if (auto value = GetEnvValue("QRY_MAX_OUTBOUND_PEERS")) {
+    opts->max_outbound_peers = static_cast<std::size_t>(std::stoul(*value));
+  }
+  if (auto value = GetEnvValue("QRY_MAX_TOTAL_PEERS")) {
+    opts->max_total_peers = static_cast<std::size_t>(std::stoul(*value));
+  }
 }
 
 std::string NormalizeKey(std::string key) {

--- a/tests/unit/net/peer_manager_tests.cpp
+++ b/tests/unit/net/peer_manager_tests.cpp
@@ -114,8 +114,9 @@ bool TestInboundHandshakeThrottle() {
   const std::string address = "203.0.113.5:9375";
   const auto base = std::chrono::steady_clock::now();
 
-  // Default limits: allow a small burst then reject within the window.
-  for (int i = 0; i < 8; ++i) {
+  // Default limits: allow a burst of 32 per host then reject within the window.
+  // (Limit was increased from 8 to 32 to handle burst traffic on seed nodes.)
+  for (int i = 0; i < 32; ++i) {
     if (!qryptcoin::net::PeerManagerTestHelper::AllowInboundBeforeHandshake(manager, address, base)) {
       std::cerr << "expected inbound attempt " << i << " to be allowed\n";
       return false;


### PR DESCRIPTION
## Summary
- Replace drop-on-capacity with intelligent peer eviction (evict idle peers when at capacity)
- Increase default limits for high-traffic seed nodes (500 inbound, 512 total)
- Add environment variable support: `QRY_MAX_INBOUND_PEERS`, `QRY_MAX_OUTBOUND_PEERS`, `QRY_MAX_TOTAL_PEERS`
- Raise throttle limits and listener backlog for burst handling

## Test plan
- [x] Deployed to seed node - accepting connections without throttle errors
- [x] Verified all production nodes are synced
- [x] CI tests pass