### PR TITLE
Remove unreachable server from automated deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        server: [1, 2, 3]
+        server: [1, 2]
     steps:
       - name: Deploy to server ${{ matrix.server }}
         uses: appleboy/ssh-action@v1.0.3


### PR DESCRIPTION
Server 3 (local network) is not reachable from GitHub Actions. Removing it from the automated deployment matrix to prevent workflow failures.