### PR TITLE
Exclude explorer directory from CodeQL analysis

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -2,3 +2,4 @@ name: "QryptCoin CodeQL configuration"
 paths-ignore:
   - vendor/**
   - third_party/**
+  - explorer/**


### PR DESCRIPTION
Fixes CodeQL JavaScript analysis failure by excluding the explorer directory which contains UI patch scripts that aren't meant for static analysis.