### PR TITLE
Add Telegram community link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This implementation enforces the consensus rules described in the protocol docum
 - **Block Explorer**: [explorer.qryptcoin.org](https://explorer.qryptcoin.org)
 - **Mempool Explorer**: [mempool.qryptcoin.org](https://mempool.qryptcoin.org)
 - **Website**: [qryptcoin.org](https://qryptcoin.org)
-- **Telegram Channel**: [t.me/qryptcoin](https://t.me/qryptcoin)
+- **Telegram**: [Community](https://t.me/+6_x6VRa_eRZmODBh)
 
 
 ## Repository contents


### PR DESCRIPTION
Adds the new Telegram community group link alongside the announcements channel.