### PR TITLE
Update Telegram invite link to require approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This implementation enforces the consensus rules described in the protocol docum
 - **Block Explorer**: [explorer.qryptcoin.org](https://explorer.qryptcoin.org)
 - **Mempool Explorer**: [mempool.qryptcoin.org](https://mempool.qryptcoin.org)
 - **Website**: [qryptcoin.org](https://qryptcoin.org)
-- **Telegram**: [Community](https://t.me/+6_x6VRa_eRZmODBh)
+- **Telegram**: [Community](https://t.me/+uCf5QzVtJxlkM2Ix)
 
 
 ## Repository contents


### PR DESCRIPTION
## Summary

- Update Telegram community invite link to use a new link with `creates_join_request: true`
- Old links were allowing users to join without admin approval

## Details

The previous invite link was created without the approval requirement flag, allowing anyone to join directly. This PR updates to a new invite link that enforces join request approval via the Telegram bot.

## Test plan

- [x] Verified new link has `creates_join_request: true`
- [x] Revoked old invite links
- [x] Bot service is active and listening for join requests