### PR TITLE
Add path filters to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,19 @@ name: Deploy
 on:
   push:
     branches: [main]
-  workflow_dispatch:
+    paths:
+      # Only deploy when actual source code or build files change
+      - 'src/**'
+      - 'include/**'
+      - 'CMakeLists.txt'
+      - 'cmake/**'
+      - 'vendor/**'
+      - 'third_party/**'
+      # Exclude documentation, CI config, and other non-binary changes
+      - '!**.md'
+      - '!.github/**'
+      - '!docs/**'
+  workflow_dispatch:  # Manual trigger for when you need to force deploy
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Prevents unnecessary deployments (and qryptd restarts) when non-code files change.

## Problem

Every push to main triggers the deploy workflow, which restarts qryptd on the servers. This causes:
- Blockchain re-sync delays
- Mempool explorer to show stale/resetting data
- Unnecessary server load

## Solution

Add path filters so deployment only triggers when:
- `src/**`, `include/**` - source code
- `CMakeLists.txt`, `cmake/**` - build system
- `vendor/**`, `third_party/**` - dependencies

Deployment is skipped for:
- `**.md` - documentation
- `.github/**` - CI configuration
- `docs/**` - documentation

Manual deployment is still available via `workflow_dispatch`.

## Test plan

- [x] Verified path filter syntax
- [ ] CI should pass (this change won't trigger deploy itself)